### PR TITLE
snap: revert to version `2.44.2`

### DIFF
--- a/webkitgtk-6-gnome-2204-sdk/snapcraft.yaml
+++ b/webkitgtk-6-gnome-2204-sdk/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: webkitgtk-6-gnome-2204-sdk
 base: core22
-version: "2.45.2"
+version: "2.44.2"
 summary: Web content engine for GTK(SDK)
 description: |
   SDK snap for Webkitgtk-6.0+, used with gnome-42-2204 and core22.
@@ -18,7 +18,7 @@ parts:
   webkitgtk-6-gnome-2204-sdk:
     #source: https://webkitgtk.org/releases/webkitgtk-2.40.1.tar.xz
     source: https://github.com/WebKit/WebKit.git
-    source-tag: "webkitgtk-2.45.2"
+    source-tag: "webkitgtk-2.44.2"
     source-depth: 1
     plugin: cmake
     cmake-parameters:

--- a/webkitgtk-6-gnome-2204/snapcraft.yaml
+++ b/webkitgtk-6-gnome-2204/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: webkitgtk-6-gnome-2204
 base: core22
-version: "2.45.2"
+version: "2.44.2"
 summary: Web content engine for GTK
 description: |
   Content snap for Webkitgtk-6.0+


### PR DESCRIPTION
For some weird reason, `2.52.2` stopped building in `arm64`. Can't find any fix to this. Logs got

```bash
In file included from /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/simde.h:37,
2024-05-28T12:42:24.1347674Z ::                  from /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/SIMDHelpers.h:30,
2024-05-28T12:42:24.1348580Z ::                  from /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/text/StringCommon.h:34,
2024-05-28T12:42:24.1349468Z ::                  from /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/text/StringImpl.h:40,
2024-05-28T12:42:24.1350351Z ::                  from /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/text/WTFString.h:28,
2024-05-28T12:42:24.1351252Z ::                  from /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/LoggingAccumulator.h:28,
2024-05-28T12:42:24.1352119Z ::                  from /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/Assertions.cpp:37:
2024-05-28T12:42:24.1354406Z :: /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/arm/neon.h: In function ‘simde_float16x4_t simde_vcadd_rot270_f16(simde_float16x4_t, simde_float16x4_t)’:
2024-05-28T12:42:24.1356382Z :: /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/arm/neon.h:7410:83: error: too many initializers for ‘__vector(2) short int’
2024-05-28T12:42:24.1356740Z ::  7410 |          int##elem_size##_t SIMDE_VECTOR(vec_size) simde_shuffle_ = { __VA_ARGS__ }; \
2024-05-28T12:42:24.1357138Z ::       |                                                                                   ^
2024-05-28T12:42:24.1359303Z :: /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/arm/neon.h:30269:19: note: in expansion of macro ‘SIMDE_SHUFFLE_VECTOR_’
2024-05-28T12:42:24.1360136Z :: 30269 |       b_.values = SIMDE_SHUFFLE_VECTOR_(16, 4, -b_.values, b_.values, 5, 0, 7, 2);
2024-05-28T12:42:24.1360378Z ::       |                   ^~~~~~~~~~~~~~~~~~~~~
2024-05-28T12:42:24.1363225Z :: /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/arm/neon.h:7411:12: error: ‘__builtin_shuffle’ number of elements of the argument vector(s) and the mask vector should be the same
2024-05-28T12:42:24.1363572Z ::  7411 |            __builtin_shuffle(a, b, simde_shuffle_); \
2024-05-28T12:42:24.1363759Z ::       |            ^~~~~~~~~~~~~~~~~
2024-05-28T12:42:24.1366022Z :: /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/arm/neon.h:30269:19: note: in expansion of macro ‘SIMDE_SHUFFLE_VECTOR_’
2024-05-28T12:42:24.1367024Z :: 30269 |       b_.values = SIMDE_SHUFFLE_VECTOR_(16, 4, -b_.values, b_.values, 5, 0, 7, 2);
2024-05-28T12:42:24.1367286Z ::       |                   ^~~~~~~~~~~~~~~~~~~~~
2024-05-28T12:42:24.1368571Z :: /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/arm/neon.h:7409:84: error: void value not ignored as it ought to be
2024-05-28T12:42:24.1368903Z ::  7409 | #      define SIMDE_SHUFFLE_VECTOR_(elem_size, vec_size, a, b, ...) (__extension__ ({ \
2024-05-28T12:42:24.1369093Z ::       |                                                                     ~~~~~~~~~~~~~~~^~~~
2024-05-28T12:42:24.1369411Z ::  7410 |          int##elem_size##_t SIMDE_VECTOR(vec_size) simde_shuffle_ = { __VA_ARGS__ }; \
2024-05-28T12:42:24.1369626Z ::       |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2024-05-28T12:42:24.1370023Z ::  7411 |            __builtin_shuffle(a, b, simde_shuffle_); \
2024-05-28T12:42:24.1370191Z ::       |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2024-05-28T12:42:24.1370303Z ::  7412 |          }))
2024-05-28T12:42:24.1370403Z ::       |          ~~~
2024-05-28T12:42:24.1371610Z :: /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/arm/neon.h:30269:19: note: in expansion of macro ‘SIMDE_SHUFFLE_VECTOR_’
2024-05-28T12:42:24.1372024Z :: 30269 |       b_.values = SIMDE_SHUFFLE_VECTOR_(16, 4, -b_.values, b_.values, 5, 0, 7, 2);
2024-05-28T12:42:24.1372165Z ::       |                   ^~~~~~~~~~~~~~~~~~~~~
2024-05-28T12:42:24.1373520Z :: /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/arm/neon.h: In function ‘simde_float16x8_t simde_vcaddq_rot270_f16(simde_float16x8_t, simde_float16x8_t)’:
2024-05-28T12:42:24.1374728Z :: /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/arm/neon.h:7410:83: error: too many initializers for ‘__vector(4) short int’
2024-05-28T12:42:24.1375039Z ::  7410 |          int##elem_size##_t SIMDE_VECTOR(vec_size) simde_shuffle_ = { __VA_ARGS__ }; \
2024-05-28T12:42:24.1375226Z ::       |                                                                                   ^
2024-05-28T12:42:24.1376383Z :: /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/arm/neon.h:30299:19: note: in expansion of macro ‘SIMDE_SHUFFLE_VECTOR_’
2024-05-28T12:42:24.1376860Z :: 30299 |       b_.values = SIMDE_SHUFFLE_VECTOR_(16, 8, -b_.values, b_.values, 9, 0, 11, 2, 13, 4, 15, 6);
2024-05-28T12:42:24.1376999Z ::       |                   ^~~~~~~~~~~~~~~~~~~~~
2024-05-28T12:42:24.1378602Z :: /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/arm/neon.h:7411:12: error: ‘__builtin_shuffle’ number of elements of the argument vector(s) and the mask vector should be the same
2024-05-28T12:42:24.1378808Z ::  7411 |            __builtin_shuffle(a, b, simde_shuffle_); \
2024-05-28T12:42:24.1378931Z ::       |            ^~~~~~~~~~~~~~~~~
2024-05-28T12:42:24.1380099Z :: /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/arm/neon.h:30299:19: note: in expansion of macro ‘SIMDE_SHUFFLE_VECTOR_’
2024-05-28T12:42:24.1380561Z :: 30299 |       b_.values = SIMDE_SHUFFLE_VECTOR_(16, 8, -b_.values, b_.values, 9, 0, 11, 2, 13, 4, 15, 6);
2024-05-28T12:42:24.1380692Z ::       |                   ^~~~~~~~~~~~~~~~~~~~~
2024-05-28T12:42:24.1381836Z :: /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/arm/neon.h:7409:84: error: void value not ignored as it ought to be
2024-05-28T12:42:24.1382173Z ::  7409 | #      define SIMDE_SHUFFLE_VECTOR_(elem_size, vec_size, a, b, ...) (__extension__ ({ \
2024-05-28T12:42:24.1382349Z ::       |                                                                     ~~~~~~~~~~~~~~~^~~~
2024-05-28T12:42:24.1382653Z ::  7410 |          int##elem_size##_t SIMDE_VECTOR(vec_size) simde_shuffle_ = { __VA_ARGS__ }; \
2024-05-28T12:42:24.1383096Z ::       |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2024-05-28T12:42:24.1383306Z ::  7411 |            __builtin_shuffle(a, b, simde_shuffle_); \
2024-05-28T12:42:24.1383460Z ::       |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2024-05-28T12:42:24.1383568Z ::  7412 |          }))
2024-05-28T12:42:24.1383671Z ::       |          ~~~
2024-05-28T12:42:24.1384869Z :: /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/arm/neon.h:30299:19: note: in expansion of macro ‘SIMDE_SHUFFLE_VECTOR_’
2024-05-28T12:42:24.1385503Z :: 30299 |       b_.values = SIMDE_SHUFFLE_VECTOR_(16, 8, -b_.values, b_.values, 9, 0, 11, 2, 13, 4, 15, 6);
2024-05-28T12:42:24.1385639Z ::       |                   ^~~~~~~~~~~~~~~~~~~~~
2024-05-28T12:42:24.1386984Z :: /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/arm/neon.h: In function ‘simde_float16x4_t simde_vcadd_rot90_f16(simde_float16x4_t, simde_float16x4_t)’:
2024-05-28T12:42:24.1388167Z :: /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/arm/neon.h:7410:83: error: too many initializers for ‘__vector(2) short int’
2024-05-28T12:42:24.1388465Z ::  7410 |          int##elem_size##_t SIMDE_VECTOR(vec_size) simde_shuffle_ = { __VA_ARGS__ }; \
2024-05-28T12:42:24.1388652Z ::       |                                                                                   ^
2024-05-28T12:42:24.1389825Z :: /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/arm/neon.h:30463:19: note: in expansion of macro ‘SIMDE_SHUFFLE_VECTOR_’
2024-05-28T12:42:24.1390231Z :: 30463 |       b_.values = SIMDE_SHUFFLE_VECTOR_(16, 4, -b_.values, b_.values, 1, 4, 3, 6);
2024-05-28T12:42:24.1390367Z ::       |                   ^~~~~~~~~~~~~~~~~~~~~
2024-05-28T12:42:24.1391805Z :: /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/arm/neon.h:7411:12: error: ‘__builtin_shuffle’ number of elements of the argument vector(s) and the mask vector should be the same
2024-05-28T12:42:24.1392002Z ::  7411 |            __builtin_shuffle(a, b, simde_shuffle_); \
2024-05-28T12:42:24.1392117Z ::       |            ^~~~~~~~~~~~~~~~~
2024-05-28T12:42:24.1393442Z :: /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/arm/neon.h:30463:19: note: in expansion of macro ‘SIMDE_SHUFFLE_VECTOR_’
2024-05-28T12:42:24.1393864Z :: 30463 |       b_.values = SIMDE_SHUFFLE_VECTOR_(16, 4, -b_.values, b_.values, 1, 4, 3, 6);
2024-05-28T12:42:24.1394002Z ::       |                   ^~~~~~~~~~~~~~~~~~~~~
2024-05-28T12:42:24.1395159Z :: /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/arm/neon.h:7409:84: error: void value not ignored as it ought to be
2024-05-28T12:42:24.1395490Z ::  7409 | #      define SIMDE_SHUFFLE_VECTOR_(elem_size, vec_size, a, b, ...) (__extension__ ({ \
2024-05-28T12:42:24.1395673Z ::       |                                                                     ~~~~~~~~~~~~~~~^~~~
2024-05-28T12:42:24.1395989Z ::  7410 |          int##elem_size##_t SIMDE_VECTOR(vec_size) simde_shuffle_ = { __VA_ARGS__ }; \
2024-05-28T12:42:24.1396187Z ::       |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2024-05-28T12:42:24.1396383Z ::  7411 |            __builtin_shuffle(a, b, simde_shuffle_); \
2024-05-28T12:42:24.1396541Z ::       |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2024-05-28T12:42:24.1396643Z ::  7412 |          }))
2024-05-28T12:42:24.1396747Z ::       |          ~~~
2024-05-28T12:42:24.1397928Z :: /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/arm/neon.h:30463:19: note: in expansion of macro ‘SIMDE_SHUFFLE_VECTOR_’
2024-05-28T12:42:24.1398328Z :: 30463 |       b_.values = SIMDE_SHUFFLE_VECTOR_(16, 4, -b_.values, b_.values, 1, 4, 3, 6);
2024-05-28T12:42:24.1398458Z ::       |                   ^~~~~~~~~~~~~~~~~~~~~
2024-05-28T12:42:24.1399801Z :: /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/arm/neon.h: In function ‘simde_float16x8_t simde_vcaddq_rot90_f16(simde_float16x8_t, simde_float16x8_t)’:
2024-05-28T12:42:24.1401125Z :: /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/arm/neon.h:7410:83: error: too many initializers for ‘__vector(4) short int’
2024-05-28T12:42:24.1401433Z ::  7410 |          int##elem_size##_t SIMDE_VECTOR(vec_size) simde_shuffle_ = { __VA_ARGS__ }; \
2024-05-28T12:42:24.1401610Z ::       |                                                                                   ^
2024-05-28T12:42:24.1402769Z :: /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/arm/neon.h:30493:19: note: in expansion of macro ‘SIMDE_SHUFFLE_VECTOR_’
2024-05-28T12:42:24.1403237Z :: 30493 |       b_.values = SIMDE_SHUFFLE_VECTOR_(16, 8, -b_.values, b_.values, 1, 8, 3, 10, 5, 12, 7, 14);
2024-05-28T12:42:24.1403379Z ::       |                   ^~~~~~~~~~~~~~~~~~~~~
2024-05-28T12:42:24.1404821Z :: /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/arm/neon.h:7411:12: error: ‘__builtin_shuffle’ number of elements of the argument vector(s) and the mask vector should be the same
2024-05-28T12:42:24.1405012Z ::  7411 |            __builtin_shuffle(a, b, simde_shuffle_); \
2024-05-28T12:42:24.1405127Z ::       |            ^~~~~~~~~~~~~~~~~
2024-05-28T12:42:24.1406280Z :: /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/arm/neon.h:30493:19: note: in expansion of macro ‘SIMDE_SHUFFLE_VECTOR_’
2024-05-28T12:42:24.1406743Z :: 30493 |       b_.values = SIMDE_SHUFFLE_VECTOR_(16, 8, -b_.values, b_.values, 1, 8, 3, 10, 5, 12, 7, 14);
2024-05-28T12:42:24.1406878Z ::       |                   ^~~~~~~~~~~~~~~~~~~~~
2024-05-28T12:42:24.1408159Z :: /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/arm/neon.h:7409:84: error: void value not ignored as it ought to be
2024-05-28T12:42:24.1408490Z ::  7409 | #      define SIMDE_SHUFFLE_VECTOR_(elem_size, vec_size, a, b, ...) (__extension__ ({ \
2024-05-28T12:42:24.1408659Z ::       |                                                                     ~~~~~~~~~~~~~~~^~~~
2024-05-28T12:42:24.1408962Z ::  7410 |          int##elem_size##_t SIMDE_VECTOR(vec_size) simde_shuffle_ = { __VA_ARGS__ }; \
2024-05-28T12:42:24.1409166Z ::       |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2024-05-28T12:42:24.1409348Z ::  7411 |            __builtin_shuffle(a, b, simde_shuffle_); \
2024-05-28T12:42:24.1409505Z ::       |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2024-05-28T12:42:24.1409613Z ::  7412 |          }))
2024-05-28T12:42:24.1409712Z ::       |          ~~~
2024-05-28T12:42:24.1410888Z :: /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/arm/neon.h:30493:19: note: in expansion of macro ‘SIMDE_SHUFFLE_VECTOR_’
2024-05-28T12:42:24.1411351Z :: 30493 |       b_.values = SIMDE_SHUFFLE_VECTOR_(16, 8, -b_.values, b_.values, 1, 8, 3, 10, 5, 12, 7, 14);
2024-05-28T12:42:24.1411490Z ::       |                   ^~~~~~~~~~~~~~~~~~~~~
2024-05-28T12:42:24.1412916Z :: /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/arm/neon.h: In function ‘simde_float16x4_t simde_vcmla_lane_f16(simde_float16x4_t, simde_float16x4_t, simde_float16x4_t, int)’:
2024-05-28T12:42:24.1414102Z :: /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/arm/neon.h:7410:83: error: too many initializers for ‘__vector(2) short int’
2024-05-28T12:42:24.1414411Z ::  7410 |          int##elem_size##_t SIMDE_VECTOR(vec_size) simde_shuffle_ = { __VA_ARGS__ }; \
2024-05-28T12:42:24.1414713Z ::       |                                                                                   ^
2024-05-28T12:42:24.1415858Z :: /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/arm/neon.h:44221:17: note: in expansion of macro ‘SIMDE_SHUFFLE_VECTOR_’
2024-05-28T12:42:24.1416155Z :: 44221 |     a_.values = SIMDE_SHUFFLE_VECTOR_(16, 4, a_.values, a_.values, 0, 0, 2, 2);
2024-05-28T12:42:24.1416295Z ::       |                 ^~~~~~~~~~~~~~~~~~~~~
2024-05-28T12:42:24.1417740Z :: /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/arm/neon.h:7411:12: error: ‘__builtin_shuffle’ number of elements of the argument vector(s) and the mask vector should be the same
2024-05-28T12:42:24.1417936Z ::  7411 |            __builtin_shuffle(a, b, simde_shuffle_); \
2024-05-28T12:42:24.1418058Z ::       |            ^~~~~~~~~~~~~~~~~
2024-05-28T12:42:24.1419224Z :: /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/arm/neon.h:44221:17: note: in expansion of macro ‘SIMDE_SHUFFLE_VECTOR_’
2024-05-28T12:42:24.1419514Z :: 44221 |     a_.values = SIMDE_SHUFFLE_VECTOR_(16, 4, a_.values, a_.values, 0, 0, 2, 2);
2024-05-28T12:42:24.1419643Z ::       |                 ^~~~~~~~~~~~~~~~~~~~~
2024-05-28T12:42:24.1420783Z :: /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/arm/neon.h:7409:84: error: void value not ignored as it ought to be
2024-05-28T12:42:24.1421110Z ::  7409 | #      define SIMDE_SHUFFLE_VECTOR_(elem_size, vec_size, a, b, ...) (__extension__ ({ \
2024-05-28T12:42:24.1421288Z ::       |                                                                     ~~~~~~~~~~~~~~~^~~~
2024-05-28T12:42:24.1421706Z ::  7410 |          int##elem_size##_t SIMDE_VECTOR(vec_size) simde_shuffle_ = { __VA_ARGS__ }; \
2024-05-28T12:42:24.1421919Z ::       |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2024-05-28T12:42:24.1422112Z ::  7411 |            __builtin_shuffle(a, b, simde_shuffle_); \
2024-05-28T12:42:24.1422269Z ::       |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2024-05-28T12:42:24.1422381Z ::  7412 |          }))
2024-05-28T12:42:24.1422486Z ::       |          ~~~
2024-05-28T12:42:24.1423943Z :: /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/arm/neon.h:44221:17: note: in expansion of macro ‘SIMDE_SHUFFLE_VECTOR_’
2024-05-28T12:42:24.1424248Z :: 44221 |     a_.values = SIMDE_SHUFFLE_VECTOR_(16, 4, a_.values, a_.values, 0, 0, 2, 2);
2024-05-28T12:42:24.1424386Z ::       |                 ^~~~~~~~~~~~~~~~~~~~~
2024-05-28T12:42:24.1425836Z :: /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/arm/neon.h: In function ‘simde_float16x4_t simde_vcmla_laneq_f16(simde_float16x4_t, simde_float16x4_t, simde_float16x8_t, int)’:
2024-05-28T12:42:24.1427019Z :: /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/arm/neon.h:7410:83: error: too many initializers for ‘__vector(2) short int’
2024-05-28T12:42:24.1427318Z ::  7410 |          int##elem_size##_t SIMDE_VECTOR(vec_size) simde_shuffle_ = { __VA_ARGS__ }; \
2024-05-28T12:42:24.1427503Z ::       |                                                                                   ^
2024-05-28T12:42:24.1428656Z :: /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/arm/neon.h:44282:17: note: in expansion of macro ‘SIMDE_SHUFFLE_VECTOR_’
2024-05-28T12:42:24.1428944Z :: 44282 |     a_.values = SIMDE_SHUFFLE_VECTOR_(16, 4, a_.values, a_.values, 0, 0, 2, 2);
2024-05-28T12:42:24.1429287Z ::       |                 ^~~~~~~~~~~~~~~~~~~~~
2024-05-28T12:42:24.1430729Z :: /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/arm/neon.h:7411:12: error: ‘__builtin_shuffle’ number of elements of the argument vector(s) and the mask vector should be the same
2024-05-28T12:42:24.1430925Z ::  7411 |            __builtin_shuffle(a, b, simde_shuffle_); \
2024-05-28T12:42:24.1431038Z ::       |            ^~~~~~~~~~~~~~~~~
2024-05-28T12:42:24.1432229Z :: /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/arm/neon.h:44282:17: note: in expansion of macro ‘SIMDE_SHUFFLE_VECTOR_’
2024-05-28T12:42:24.1432519Z :: 44282 |     a_.values = SIMDE_SHUFFLE_VECTOR_(16, 4, a_.values, a_.values, 0, 0, 2, 2);
2024-05-28T12:42:24.1432661Z ::       |                 ^~~~~~~~~~~~~~~~~~~~~
2024-05-28T12:42:24.1433797Z :: /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/arm/neon.h:7409:84: error: void value not ignored as it ought to be
2024-05-28T12:42:24.1434127Z ::  7409 | #      define SIMDE_SHUFFLE_VECTOR_(elem_size, vec_size, a, b, ...) (__extension__ ({ \
2024-05-28T12:42:24.1434303Z ::       |                                                                     ~~~~~~~~~~~~~~~^~~~
2024-05-28T12:42:24.1434607Z ::  7410 |          int##elem_size##_t SIMDE_VECTOR(vec_size) simde_shuffle_ = { __VA_ARGS__ }; \
2024-05-28T12:42:24.1434797Z ::       |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2024-05-28T12:42:24.1434987Z ::  7411 |            __builtin_shuffle(a, b, simde_shuffle_); \
2024-05-28T12:42:24.1435145Z ::       |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2024-05-28T12:42:24.1435248Z ::  7412 |          }))
2024-05-28T12:42:24.1435504Z ::       |          ~~~
2024-05-28T12:42:24.1436677Z :: /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/arm/neon.h:44282:17: note: in expansion of macro ‘SIMDE_SHUFFLE_VECTOR_’
2024-05-28T12:42:24.1436972Z :: 44282 |     a_.values = SIMDE_SHUFFLE_VECTOR_(16, 4, a_.values, a_.values, 0, 0, 2, 2);
2024-05-28T12:42:24.1437103Z ::       |                 ^~~~~~~~~~~~~~~~~~~~~
2024-05-28T12:42:24.1438525Z :: /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/arm/neon.h: In function ‘simde_float16x8_t simde_vcmlaq_lane_f16(simde_float16x8_t, simde_float16x8_t, simde_float16x4_t, int)’:
2024-05-28T12:42:24.1439708Z :: /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/arm/neon.h:7410:83: error: too many initializers for ‘__vector(2) short int’
2024-05-28T12:42:24.1440019Z ::  7410 |          int##elem_size##_t SIMDE_VECTOR(vec_size) simde_shuffle_ = { __VA_ARGS__ }; \
2024-05-28T12:42:24.1440202Z ::       |                                                                                   ^
2024-05-28T12:42:24.1441351Z :: /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/arm/neon.h:44345:20: note: in expansion of macro ‘SIMDE_SHUFFLE_VECTOR_’
2024-05-28T12:42:24.1441684Z :: 44345 |     a_low.values = SIMDE_SHUFFLE_VECTOR_(16, 4, a_low.values, a_low.values, 0, 0, 2, 2);
2024-05-28T12:42:24.1441820Z ::       |                    ^~~~~~~~~~~~~~~~~~~~~
2024-05-28T12:42:24.1443264Z :: /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/arm/neon.h:7411:12: error: ‘__builtin_shuffle’ number of elements of the argument vector(s) and the mask vector should be the same
2024-05-28T12:42:24.1443462Z ::  7411 |            __builtin_shuffle(a, b, simde_shuffle_); \
2024-05-28T12:42:24.1443705Z ::       |            ^~~~~~~~~~~~~~~~~
2024-05-28T12:42:24.1444854Z :: /build/snapcraft-webkitgtk-6-gnome-2204-sdk-9848c6b03cbc37c190ea1b23456ac7ca/parts/webkitgtk-6-gnome-2204-sdk/src/Source/WTF/wtf/simde/arm/neon.h:44345:20: note: in expansion of macro ‘SIMDE_SHUFFLE_VECTOR_’
2024-05-28T12:42:24.1445177Z :: 44345 |     a_low.values = SIMDE_SHUFFLE_VECTOR_(16, 4, a_low.values, a_low.values, 0, 0, 2, 2);
2024-05-28T12:42:24.1445314Z ::       |                    ^~~~~~~~~~~~~~~~~~~~~
2024-05-28T12:42:24.1445550Z :: compilation terminated due to -fmax-errors=20.
2024-05-28T12:42:24.1446065Z :: gmake[2]: *** [Source/WTF/wtf/CMakeFiles/WTF.dir/build.make:104: Source/WTF/wtf/CMakeFiles/WTF.dir/Assertions.cpp.o] Error 1
2024-05-28T12:42:24.1446761Z :: gmake***: *** [CMakeFiles/Makefile2:531: Source/WTF/wtf/CMakeFiles/WTF.dir/all] Error 2
2024-05-28T12:42:24.1446958Z :: gmake***: *** Waiting for unfinished jobs....
```