### PR TITLE
ci: remove the hardcoded tag & fix content snap release

### DIFF
--- a/.github/workflows/release-content-to-candidate.yml
+++ b/.github/workflows/release-content-to-candidate.yml
@@ -4,6 +4,7 @@ on:
   workflow_run:
     workflows: ["Release webkitgtk-6-gnome-2404-sdk to candidate"]
     types: [completed]
+    branches: ["2404"]
     paths:
       - "webkitgtk-6-gnome-2404/**"
   workflow_dispatch:

--- a/.github/workflows/update-sdk-snap.yml
+++ b/.github/workflows/update-sdk-snap.yml
@@ -25,7 +25,8 @@ jobs:
           branch: "2404"
           snapcraft-project-root: "webkitgtk-6-gnome-2404-sdk"
           update-script: |
-            webkitgtk_version=$(curl -s 'https://gitlab.gnome.org/GNOME/gnome-build-meta/-/raw/46.2/elements/sdk/webkitgtk.inc?ref_type=tags' | yq eval '.sources[0].url' | cut -d : -f 2 | cut -d - -f 2 | cut -c -6)
+            latest_tag=$(git ls-remote --refs --sort='v:refname' --tags https://gitlab.gnome.org/GNOME/gnome-build-meta.git | awk -F'/' '{print $NF}' | grep -E '^[0-9]+(\.[0-9]+)*$' | sort -V | tail -n 1)
+            webkitgtk_version=$(curl -s "https://gitlab.gnome.org/GNOME/gnome-build-meta/-/raw/${latest_tag}/elements/sdk/webkitgtk.inc?ref_type=tags" | yq eval '.sources[0].url' | cut -d : -f 2 | cut -d - -f 2 | cut -c -6)
             yq -i ".version=\"$webkitgtk_version\"" webkitgtk-6-gnome-2404-sdk/snapcraft.yaml
 
   sync-content-version:
@@ -41,5 +42,6 @@ jobs:
           branch: "2404"
           snapcraft-project-root: "webkitgtk-6-gnome-2404"
           update-script: |
-            webkitgtk_version=$(curl -s 'https://gitlab.gnome.org/GNOME/gnome-build-meta/-/raw/46.2/elements/sdk/webkitgtk.inc?ref_type=tags' | yq eval '.sources[0].url' | cut -d : -f 2 | cut -d - -f 2 | cut -c -6)
+            latest_tag=$(git ls-remote --refs --sort='v:refname' --tags https://gitlab.gnome.org/GNOME/gnome-build-meta.git | awk -F'/' '{print $NF}' | grep -E '^[0-9]+(\.[0-9]+)*$' | sort -V | tail -n 1)
+            webkitgtk_version=$(curl -s "https://gitlab.gnome.org/GNOME/gnome-build-meta/-/raw/${latest_tag}/elements/sdk/webkitgtk.inc?ref_type=tags" | yq eval '.sources[0].url' | cut -d : -f 2 | cut -d - -f 2 | cut -c -6)
             yq -i ".version=\"$webkitgtk_version\"" webkitgtk-6-gnome-2404/snapcraft.yaml


### PR DESCRIPTION
In my previous PR I accidentally hard coded the gnome-sdk's tag which we're gonna follow now, because they have a control on the webkitgtk's api. So, I think it's a better idea to follow their release style. Because, we might need some patches also with each tag.

Also, this PR specifies the branch for the content snap workflow, for it to work properly.