### PR TITLE
avoid priming any libraries provided by gpu-2404 content providers

### DIFF
--- a/webkitgtk-6-gnome-2404-sdk/snapcraft.yaml
+++ b/webkitgtk-6-gnome-2404-sdk/snapcraft.yaml
@@ -104,3 +104,14 @@ parts:
          sed -i '1cprefix=/snap/webkitgtk-6-gnome-2404-sdk/current/usr' $PC
          sed -i 's#libdir=/usr/lib#libdir=${prefix}/lib#' $PC
       done
+
+  # avoid priming any libraries provided by gpu-2404 content providers
+  gpu-2404:
+    after: [pkg-config-fix]
+    source: https://github.com/canonical/gpu-snap.git
+    plugin: dump
+    override-prime: |
+      craftctl default
+      ${CRAFT_PART_SRC}/bin/gpu-2404-cleanup mesa-2404 nvidia-2404
+    prime:
+      - bin/gpu-2404-wrapper


### PR DESCRIPTION
This should make webkitgtk-sdk work with the current stable mesa-2404, the current version is fragile: only if the snaps have the same content will things work.

C.f. https://github.com/canonical/mesa-2404/issues/4 & https://forum.snapcraft.io/t/call-for-testing-mesa-2404-24-0-9-update/41124/3