### PR TITLE
fix(ci): fix the update logic for content snap

### DIFF
--- a/.github/workflows/update-snap.yml
+++ b/.github/workflows/update-snap.yml
@@ -1,4 +1,4 @@
-name: Update SDK Snap
+name: Update Snap
 
 on:
   # Runs at 10:00 UTC every day
@@ -41,6 +41,5 @@ jobs:
           branch: "2404"
           snapcraft-project-root: "webkitgtk-6-gnome-2404"
           update-script: |
-            latest_tag=$(git ls-remote --refs --sort='v:refname' --tags https://gitlab.gnome.org/GNOME/gnome-build-meta.git | awk -F'/' '{print $NF}' | grep -E '^[0-9]+(\.[0-9]+)*$' | sort -V | tail -n 1)
-            webkitgtk_version=$(curl -s "https://gitlab.gnome.org/GNOME/gnome-build-meta/-/raw/${latest_tag}/elements/sdk/webkitgtk.inc?ref_type=tags" | yq eval '.sources[0].url' | cut -d : -f 2 | cut -d - -f 2 | cut -c -6)
+            webkitgtk_version=$(git ls-remote --refs --sort='v:refname' --tags 'https://github.com/WebKit/WebKit.git' "webkitgtk-*" | awk -F'/' '{print $NF}' | grep -E 'webkitgtk-[0-9]+(\.[0-9]+)*\.[0-9]$' | sort -V | tail -n 1 | sed 's/^webkitgtk-//') 
             yq -i ".version=\"$webkitgtk_version\"" webkitgtk-6-gnome-2404/snapcraft.yaml

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <ul>
 <a href="https://snapcraft.io/webkitgtk-6-gnome-2204-sdk"><img src="https://snapcraft.io/webkitgtk-6-gnome-2204-sdk/badge.svg" alt="WebKitGTK SDK Status"></a>
-<a href="https://github.com/snapcrafters/webkitgtk-sdk/actions/workflows/update-sdk-snap.yml"><img src="https://github.com/snapcrafters/webkitgtk-sdk/actions/workflows/update-sdk-snap.yml/badge.svg"></a>
+<a href="https://github.com/snapcrafters/webkitgtk-sdk/actions/workflows/update-snap.yml"><img src="https://github.com/snapcrafters/webkitgtk-sdk/actions/workflows/update-snap.yml/badge.svg"></a>
 
 <a href="https://github.com/snapcrafters/webkitgtk-sdk/actions/workflows/release-sdk-to-candidate.yaml"><img src="https://github.com/snapcrafters/webkitgtk-sdk/actions/workflows/release-sdk-to-candidate.yml/badge.svg"></a>
 <a href="https://github.com/snapcrafters/webkitgtk-sdk/actions/workflows/promote-to-stable.yml"><img src="https://github.com/snapcrafters/webkitgtk-sdk/actions/workflows/promote-to-stable.yml/badge.svg"></a>
@@ -21,7 +21,7 @@
 
 <ul>
 <a href="https://snapcraft.io/webkitgtk-6-gnome-2204"><img src="https://snapcraft.io/webkitgtk-6-gnome-2204/badge.svg" alt="WebKitGTK Content Snap Status"></a>
-<a href="https://github.com/snapcrafters/webkitgtk-sdk/actions/workflows/update-sdk-snap.yml"><img src="https://github.com/snapcrafters/webkitgtk-sdk/actions/workflows/update-sdk-snap.yml/badge.svg"></a>
+<a href="https://github.com/snapcrafters/webkitgtk-sdk/actions/workflows/update-snap.yml"><img src="https://github.com/snapcrafters/webkitgtk-sdk/actions/workflows/update-snap.yml/badge.svg"></a>
 <a href="https://github.com/snapcrafters/webkitgtk-sdk/actions/workflows/release-content-to-candidate.yaml"><img src="https://github.com/snapcrafters/webkitgtk-sdk/actions/workflows/release-content-to-candidate.yml/badge.svg"></a>
 <a href="https://github.com/snapcrafters/webkitgtk-sdk/actions/workflows/promote-to-stable.yml"><img src="https://github.com/snapcrafters/webkitgtk-sdk/actions/workflows/promote-to-stable.yml/badge.svg"></a>
 </ul>

--- a/webkitgtk-6-gnome-2404/snapcraft.yaml
+++ b/webkitgtk-6-gnome-2404/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: webkitgtk-6-gnome-2404
 base: core24
-version: "2.48.3"
+version: "2.49.2"
 summary: Web content engine for GTK
 description: |
   Content snap for Webkitgtk-6.0+


### PR DESCRIPTION
rename the workflow to update-snap as it updates both the sdk and the content snap.

update the content snap to the same version as the sdk snap.