### PR TITLE
fix: patch Skia big-endian build on s390x

### DIFF
--- a/webkitgtk-6-gnome-2404-sdk/patches/fix-skia-s390x-big-endian.patch
+++ b/webkitgtk-6-gnome-2404-sdk/patches/fix-skia-s390x-big-endian.patch
@@ -1,0 +1,34 @@
+diff --git a/Source/ThirdParty/skia/CMakeLists.txt b/Source/ThirdParty/skia/CMakeLists.txt
+index 607a4b0f..8f3b8b9d 100644
+--- a/Source/ThirdParty/skia/CMakeLists.txt
++++ b/Source/ThirdParty/skia/CMakeLists.txt
+@@ -1090,10 +1090,13 @@ if (CMAKE_CXX_BYTE_ORDER STREQUAL "BIG_ENDIAN")
+     target_compile_definitions(Skia PUBLIC
+         I_ACKNOWLEDGE_SKIA_DOES_NOT_SUPPORT_BIG_ENDIAN
+ 
+-        SK_R32_SHIFT=24
+-        SK_G32_SHIFT=16
+-        SK_B32_SHIFT=8
+-        SK_A32_SHIFT=0
++        # Keep the channel packing in one of Skia's supported 32-bit orders.
++        # The upstream big-endian ARGB shifts trip SkColorPriv/SkTypes asserts
++        # during the s390x SDK build.
++        SK_R32_SHIFT=0
++        SK_G32_SHIFT=8
++        SK_B32_SHIFT=16
++        SK_A32_SHIFT=24
+     )
+ else ()
+     target_compile_definitions(Skia PUBLIC
+diff --git a/Source/ThirdParty/skia/src/codec/SkCodecPriv.h b/Source/ThirdParty/skia/src/codec/SkCodecPriv.h
+index c321fb77..fabe6604 100644
+--- a/Source/ThirdParty/skia/src/codec/SkCodecPriv.h
++++ b/Source/ThirdParty/skia/src/codec/SkCodecPriv.h
+@@ -13,6 +13,7 @@
+ #include "include/core/SkImageInfo.h"
+ #include "include/core/SkTypes.h"
+ #include "include/private/SkEncodedInfo.h"
++#include "src/base/SkEndian.h"
+ #include "modules/skcms/skcms.h"
+ #include "src/codec/SkColorPalette.h"
+ #include "src/core/SkColorData.h"

--- a/webkitgtk-6-gnome-2404-sdk/snapcraft.yaml
+++ b/webkitgtk-6-gnome-2404-sdk/snapcraft.yaml
@@ -41,6 +41,9 @@ parts:
     override-pull: |
       craftctl default
       patch -p1 < ${CRAFT_PROJECT_DIR}/patches/fix-webinspectorui-jsc-dependency.patch
+      if [ "$(uname -m)" = "s390x" ]; then
+        patch -p1 < ${CRAFT_PROJECT_DIR}/patches/fix-skia-s390x-big-endian.patch
+      fi
     build-packages:
       - bubblewrap
       - gettext


### PR DESCRIPTION
Summary:
- Adds an s390x-only override-pull patch for the SDK WebKit/Skia build instead of disabling Skia/WebKit capabilities.
- Patches Skia's big-endian 32-bit channel packing to one of Skia's supported orders and includes SkEndian.h for the big-endian codec helpers.
- Applies this patch only when uname -m reports s390x; other architectures keep the existing source tree.

Evidence:
- Failed run: https://github.com/snapcrafters/webkitgtk-sdk/actions/runs/27102845658
- s390x failed in WebKit's bundled Skia with SK_*32_SHIFT packing assertions and missing SkEndianSwap16/32 declarations.

Verification:
- Parsed snapcraft.yaml with Python yaml.safe_load.
- Applied both existing and new WebKit patches against the pinned webkitgtk-2.53.3 tag in a sparse checkout.
- Ran git diff --check.
- Commit is signed.

@jnsgruk for review once PR CI/release validation has signal.
