### PR TITLE
ci: remove release workflow max-parallel limits

### DIFF
--- a/.github/workflows/release-content-to-candidate.yml
+++ b/.github/workflows/release-content-to-candidate.yml
@@ -39,9 +39,6 @@ jobs:
     environment: "2404 Branch"
     timeout-minutes: 4320
     strategy:
-      # snapcraft remote-build uses one generated Launchpad git repo/ref per
-      # run; serialize matrix legs to avoid ref-lock races between arches.
-      max-parallel: 1
       fail-fast: false
       matrix:
         architecture: ${{ fromJSON(needs.get-architectures.outputs.architectures-list) }}

--- a/.github/workflows/release-sdk-to-candidate.yml
+++ b/.github/workflows/release-sdk-to-candidate.yml
@@ -37,9 +37,6 @@ jobs:
     environment: "2404 Branch"
     timeout-minutes: 720
     strategy:
-      # snapcraft remote-build uses one generated Launchpad git repo/ref per
-      # run; serialize matrix legs to avoid ref-lock races between arches.
-      max-parallel: 1
       fail-fast: false
       matrix:
         architecture: ${{ fromJSON(needs.get-architectures.outputs.architectures-list) }}


### PR DESCRIPTION
## Summary
- Remove max-parallel limits from release-to-candidate matrix strategies.
- Drop stale serialization comments from affected release workflows.

## Validation
- Parsed all workflow YAML files with Python/PyYAML.