### PR TITLE
fix: use Ninja for WebKitGTK SDK builds

### DIFF
--- a/webkitgtk-6-gnome-2404-sdk/snapcraft.yaml
+++ b/webkitgtk-6-gnome-2404-sdk/snapcraft.yaml
@@ -22,6 +22,7 @@ parts:
     source-tag: "webkitgtk-${SNAPCRAFT_PROJECT_VERSION}"
     source-depth: 1
     plugin: cmake
+    cmake-generator: Ninja
     cmake-parameters:
       - -DPORT=GTK
       - -DCMAKE_BUILD_TYPE=Release
@@ -46,6 +47,7 @@ parts:
       fi
     build-packages:
       - bubblewrap
+      - ninja-build
       - gettext
       - gperf
       - icu-devtools


### PR DESCRIPTION
## Summary
- switch the WebKitGTK SDK CMake build to the Ninja generator
- add `ninja-build` to build packages so Launchpad remote-build workers can use it

## Why
The failing ppc64el release job hit a generated-source ordering failure under Unix Makefiles:

- `FileNotFoundError: ... CSSProperties.json`
- `No rule to make target 'WebCore/DerivedSources/JSAbstractRange.h'`
- failing job: https://github.com/snapcrafters/webkitgtk-sdk/actions/runs/27161481251/job/80312631917

WebKit's CMake-generated source graph is large and Ninja is better suited to the generated-file dependencies than Makefiles here. This keeps all existing platforms, patches, and release workflow behaviour unchanged.

## Verification
- `git diff --check`
- parsed `webkitgtk-6-gnome-2404-sdk/snapcraft.yaml` with Python/YAML and asserted:
  - `cmake-generator: Ninja`
  - `ninja-build` is in build-packages
  - `ppc64el` remains in platforms
- `snapcraft expand-extensions` accepts the project and preserves `cmake-generator: Ninja` / `ninja-build`

@jnsgruk
